### PR TITLE
feat: Adding alternative to `main()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,8 @@ Advantage of `main()` function: Kills actor even if you forgot `setTimeout()`
 
 #### Node.js
 
+In Node.js the actor code might be either wrapped using the main function:
+
 ```js
 import { Actor } from 'apify';
 
@@ -434,6 +436,20 @@ Actor.main(async () => {
   // ...
 });
 ```
+
+Or in combination with ES modules supporting usage of the top level `await` operator wrapped by `init()` and `exit()` methods:
+
+```js
+import { Actor } from 'apify';
+
+await Actor.init();
+
+const input = await Actor.getInput();
+console.log(input);
+
+await Actor.exit();
+```
+
 
 #### UNIX equivalent
 


### PR DESCRIPTION
- Perhaps we could promote just the newer version, but that currently works only in newer NodeJS that supports ES modules
- We should consider here how it's going to be done in Python. What do you think @fnesveda? If we need `main()` in Python then for a sake of consistency, we could keep it in NodeJS too.