### PR TITLE
feat: Experimenting with the definition of multiple datasets

### DIFF
--- a/pages/ACTOR.md
+++ b/pages/ACTOR.md
@@ -26,9 +26,9 @@ It looks as follows:
     "keyValueStore": "./key_value_store_schema.json",
     "dataset": {
       // The default dataset uses a propper linked schema here.
-      "default": "../shared-schemas/default_dataset_schema.json",
+      "@default": "../shared-schemas/default_dataset_schema.json",
       // Here we don't want to validate so we use only a title and description.
-      "invalidItems": { "title": "Invalid items", "description": "Dataset items not matching the schema" }
+      "@invalidItems": { "title": "Invalid items", "description": "Dataset items not matching the schema" }
     },
     "requestQueue": "../shared-schemas/request_queue_schema.json" // Support of shared schemas in monorepo
   }
@@ -42,19 +42,21 @@ Apify platform will then create unnamed datasets (or we do lazy creation) and as
   "storages": {
     ...
     "datasets": {
-      "default": "n4erFvn7gb2h43wZs",
-      "invalidItems": "228oAtKGLehjnh8eS"
+      "@default": "n4erFvn7gb2h43wZs",
+      "@invalidItems": "228oAtKGLehjnh8eS"
     }
     ...
   }
   ...
 ```
 
-Apify platform (or CLI) will then pass these IDs to the Actor via environment variable:
+The Apify platform (or CLI) will then pass these IDs to the Actor via environment variable `ACTOR_DATASET_IDS`:
 
 ```
-ACTOR_DEFAULT_DATASET_ID=n4erFvn7gb2h43wZs
-ACTOR_INVALID_ITEMS_DATASET_ID=228oAtKGLehjnh8eS
+{
+      "@default": "n4erFvn7gb2h43wZs",
+      "@invalidItems": "228oAtKGLehjnh8eS"
+}
 ```
 
 Usage in SDKs:
@@ -71,16 +73,7 @@ try {
 }
 ```
 
-Or with a shortcut:
-
-```js
-const dataset = await Apify.openDataset('@default', { invalidItemsDatasetName: '@invalidItems' });
-
-await dataset.pushData(item);
-```
-
 ---
-
 
 The `.actor/actor.json` replaces the legacy `apify.json` file.
 Here are the notes comparing the format to the previous version:

--- a/pages/DATASET_SCHEMA.md
+++ b/pages/DATASET_SCHEMA.md
@@ -13,13 +13,12 @@ Dataset can be assigned a schema which describes:
 
 ## Basic properties
 
-- Storage is immutable. I.e., if you want to change the structure, then you need to create a new dataset.
-- Its schema is weak. I.e., you can always push their additional properties, but schema will ensure that all the listed once are there with a correct type. This is to make actors more compatible, i.e., some actor expects dataset to contain certain fields but does not care about the additional ones.
+Dataset is **immutable**. I.e., if you want to change the structure, then you need to create a new dataset and push the transformed data into it. Dataset schema is **weak**. I.e., you can always push their additional properties, but schema will ensure that all the listed once are there with a correct type. This is to make actors more compatible, i.e., some actor expects dataset to contain certain fields but does not care about the additional ones.
 
 There are two ways how to create a dataset with schema:
 1. User can start the actor that has dataset schema linked from its
 [OUTPUT_SCHEMA.json](./OUTPUT_SCHEMA.md)
-2. Or user can do it pragmatically via API (for empty dataset) by
+1. Or user can do it pragmatically via API (for empty dataset) by
     - either by passing the schema as payload to [create dataset](https://docs.apify.com/api#/reference/datasets/dataset-collection/create-dataset) API endpoint.
     - or using the SDK:
 
@@ -27,11 +26,13 @@ There are two ways how to create a dataset with schema:
     const dataset = await Apify.openDataset('my-new-dataset', { schema });
     ```
 
-By opening an **existing** dataset with `schema` parameter, the system ensures that you are opening a dataset that is compatible with the actor as otherwise, you get an error:
+By opening an **existing** dataset with `schema` parameter, the system ensures that you are opening a dataset that is compatible with the expected schema and otherwise, you get an error:
 
 ```
 Uncaught Error: Dataset schema is not compatible with the provided schema
 ```
+
+The schema of an existing dataset is compatible if it's a superset of an expected dataset schema.
 
 ## Structure
 
@@ -41,20 +42,16 @@ Uncaught Error: Dataset schema is not compatible with the provided schema
     "title": "Eshop products",
     "description": "Dataset containing the whole product catalog including prices and stock availability.",
 
-    // Not supported yet
-    "fields": {
-        "title": "string",  
-        "imageUrl": "string",  
-        "priceUsd": "number", 
-        "manufacturer": {
-            "title": "string", 
-            "url": "number",
-        },
-        "productVariants": [{
-            "color": "?string"
-        }],
-        
-        ...
+    // Schema describing the structure of the dataset. We will allow a JSON Schema here but also a simpler version, see below.  
+    "schema": {
+      "$schema": "https://apify.com/specs/schemas/2023-09/easy-json-schema",
+      "id": "string",
+      "*name": "string",
+      "*email": "string",
+      "arr": [{
+        "site": "string",
+        "url": "string"
+      }]
     },
   
     "views": {
@@ -111,54 +108,16 @@ Uncaught Error: Dataset schema is not compatible with the provided schema
 | Property           | Type                         | Required | Description                                                                                        |
 | ------------------ | ---------------------------- | -------- | -------------------------------------------------------------------------------------------------- |
 | actorSpecification | integer                      | true     | Specifies the version of dataset schema <br/>structure document. <br/>Currently only version 1 is available. |
-| fields             | JSON schema | true     | JSON schema object with more formats in the future.             |
-| views              | [DatasetView]          | true     | An array of objects with a description of an API <br/>and UI views.                                                  |
+| schema             | (Easy) JSON schema           | true     | A schema describing the structure of the dataset. |
+| views              | [DatasetView]                | true     | An array of objects with a description of an API <br/>and UI views. |
 
 ### JSON schema
 
-Items of a dataset can be described by a JSON schema definition. Apify platform then ensures that each object accomplies with the provided schema. In the first version only the standard JSON schema will be supported, i.e.:
+Items of a dataset can be described by a JSON Schema definition. Apify platform then ensures that each object accomplies with the provided schema. We will later allow to use the full featured JSON Schema, but for now, we will use a simpler alternative. The Easy JSON Schema is a feature subset of JSON Schema that is easy to read and write:
 
-
-```jsonc
+```json
 {
-  "type": "object",
-  "required": [
-    "name",
-    "email"
-  ],
-  "properties": {
-    "id": {
-      "type": "string"
-    },
-    "name": {
-      "type": "string"
-    },
-    "email": {
-      "type": "string"
-    },
-    "arr": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [],
-        "properties": {
-          "site": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-with simplifed version comming in the near future:
-
-```jsonc
-{
+  "$schema": "https://apify.com/specs/schemas/2023-09/easy-json-schema", // This contains the JSON schema of our fork of easy JSON schema and its version (date)
   "id": "string",
   "*name": "string",
   "*email": "string",
@@ -169,6 +128,30 @@ with simplifed version comming in the near future:
 }
 ```
 
+The schema above then compiles into the following object:
+
+```json
+{
+  "$id": "https://example.com/address.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "An address similar to http://microformats.org/wiki/h-card",
+  "type": "object",
+  "properties": {
+    "post-office-box": { "type": "string" },
+    "extended-address": { "type": "string" },
+    "street-address": { "type": "string" },
+    "locality": { "type": "string" },
+    "region": { "type": "string" },
+    "postal-code": { "type": "string" },
+    "country-name": { "type": "string"  }
+  },
+  "required": [ "locality", "region", "country-name" ],
+  "dependentRequired": {
+    "post-office-box": [ "street-address" ],
+    "extended-address": [ "street-address" ]
+  }
+}
+```
 
 ### DatasetView object definition
 

--- a/pages/DATASET_SCHEMA.md
+++ b/pages/DATASET_SCHEMA.md
@@ -186,3 +186,13 @@ The schema above then compiles into the following object:
 | -------- | ------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------- |
 | label    | string                                                  | false    | In case the data are visualized as in Table view. <br/>The label will be visible table column’s header. |
 | format   | enum(text, number, date, link, <br/>boolean, image, array, object) | false    | Describes how output data values are formatted <br/>in order to be rendered in the output tab UI.       |
+
+## API behavior
+
+### Invalid item pushed to the dataset
+
+If invalid item is pushed to the dataset then API throws and error and does not push it into the dataset.
+
+If the user pushes a batch of multiple items and one of the items is invalid, the whole batch is refused with an error. 
+
+TODO: Later, we plan to extend the API with a multi-status response code enabling the API to accept some items and refuse the rest.

--- a/pages/OUTPUT_SCHEMA.md
+++ b/pages/OUTPUT_SCHEMA.md
@@ -58,6 +58,7 @@ there's no point to include storage schema here again, as it's done elsewhere.
       "title": "Product images", //optional
       "description": "Yaddada", //optional
       "collections": ["screenshots"] // optional, default means all collections in key-value-store
+      "target": "@productImages" // Key-value store defined in "ACTOR.json"
     },
     
     // If the users want to reference a single file, they do it via selecting a collection
@@ -66,7 +67,7 @@ there's no point to include storage schema here again, as it's done elsewhere.
       "type": "key-value-store",
       "title": "API server", // optional
       "collections": ["monitoringReport"],
-      "target": "default" //optional
+      "target": "@default" // optional, default store
     },
 
     // Live view


### PR DESCRIPTION
**DISCLAMER**: This is not a final PR but more of a DRAFT for discussion. After we got to final state I will finalize all the storage specs.

Notes: https://www.notion.so/apify/Dataset-validation-clean-items-e88c5a37a09b473189983faa4db92167

## Problem

As we implement item validation to the dataset, we need to figure out what to do with invalid items. We agreed on the following:
- Removing clean/unclean items functionality
- Not bounding both into the same dataset as we would have exactly the same problems to explain it as we have with unclean items
- We will use two datasets if the user wants to store invalid items somewhere

## Solution

In the PR:
- I extended `actor.json` file so that the user can define more storages per type, i.e., 2 different datasets with 2 different schemas, titles, and descriptions.
- I proposed a simple programming interface for this for an SDK

## TODOs

**BIG QUESTION**: I had a discussion earlier today with @metalwarrior665, and there are two challenges when it comes to this implementation:
- If we store invalid items in a different dataset, then we can't easily return both. This means that we won't be able to use this for "soft" validations. Where we want to validate for monitoring purposes but not for actual output for the user.
- We will have to extend monitoring to cover multiple datasets per run.

Plus, we will need to figure out how to nicely display everything in the UI, but that should be simple.

## 🗣️ "What do you think?"