### PR TITLE
feat: Allow to specify internal structure for records in KVS

### DIFF
--- a/pages/KEY_VALUE_STORE_SCHEMA.md
+++ b/pages/KEY_VALUE_STORE_SCHEMA.md
@@ -53,6 +53,7 @@ Contrary to dataset schema, the record in key-value store represents output that
             "name": "Monitoring report data",
             "description": "JSON containing the report data",
             "key": "report-data.json",
+            "contentTypes": ["application/json"],
             "jsonSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "type": "object",
@@ -60,7 +61,7 @@ Contrary to dataset schema, the record in key-value store represents output that
                     "summary": { "type": "string" },
                     "totalResults": { "type": "number" }
                 }
-            } // alternatively "schema": "./report-schema.json" can be used
+            } // alternatively "jsonSchema": "./report-schema.json" can be used
         }
     }
 }

--- a/pages/KEY_VALUE_STORE_SCHEMA.md
+++ b/pages/KEY_VALUE_STORE_SCHEMA.md
@@ -43,8 +43,28 @@ like to embed to run view for the user once the monitoring is finished.
 }
 ```
 
-For more information on how to create a key-value store with a schema, see [DATASET_SCHEMA.json](./DATASET_SCHEMA.md)
-as the implementation and API will be the same.
+3. Some Actors store a record that has a specific structure. The structure can be specified using [JSON schema](https://json-schema.org/draft-07).
+Contrary to dataset schema, the record in key-value store represents output that is a single item, instead of a sequence of items. But both approaches use JSON schema to describe the structure.
+
+```jsonc
+{
+    "collections": {
+        "monitoringReportData": {
+            "name": "Monitoring report data",
+            "description": "JSON containing the report data",
+            "key": "report-data.json",
+            "jsonSchema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                    "summary": { "type": "string" },
+                    "totalResults": { "type": "number" }
+                }
+            } // alternatively "schema": "./report-schema.json" can be used
+        }
+    }
+}
+```
 
 ## Structure
 


### PR DESCRIPTION
The specification was missing an option to make the output more structured - the structure could only be enforced by mime type.

This would allow us to generate files with a structure that is known up-front. It is useful for Actors that don't produce a sequence of items as a result but rather a single item.