### PR TITLE
feat: use collection query key instead of recordGroup

### DIFF
--- a/pages/KEY_VALUE_STORE_SCHEMA.md
+++ b/pages/KEY_VALUE_STORE_SCHEMA.md
@@ -11,7 +11,7 @@ Key-value store schema has two main use cases described in the following example
 
 1. Some Actors such as [Instagram scraper](https://apify.com/jaroslavhejlek/instagram-scraper)
 store multiple types of files into the key-value store. Let's say the scraper stores images and user pictures.
-So for each of these, we would define a prefix group and allow the user to list images from a single group in both the
+So for each of these, we would define a prefix group called collection and allow the user to list images from a single collection in both the
 UI and API.
 
 ```jsonc
@@ -94,10 +94,10 @@ Contrary to dataset schema, the record in key-value store represents output that
 
 ## API implications
 
-Enable user to list keys for specific record group:
+Enable user to list keys for specific collection:
 
 ```
-https://api.apify.com/v2/key-value-stores/storeId/keys?recordGroup=postImages&exclusiveStartKey=xxx
+https://api.apify.com/v2/key-value-stores/storeId/keys?collection=postImages&exclusiveStartKey=xxx
 ```
 
 In addition to this user will be able to list by prefix directly:


### PR DESCRIPTION
This is follow up to https://github.com/apify/actor-whitepaper/pull/9 changing `"recordGroup"` to `"collection"` in key-value store schema.