### PR TITLE
fix: update Actor bootstrap section with actual example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2101,6 +2101,8 @@ $ tree -a
 The command works on the best-effort basis,
 creating necessary configuration files for the specific programming language and libraries.
 
+Note: this command is not yet available and represents a future vision for the CLI.
+
 #### Add the Actor code
 ```
 $ cat << EOF > Dockerfile


### PR DESCRIPTION
Currently Actor boostrap section contains example with `actor bootstrap` cli command that doesn't exists anymore.

Proposed changes:
- ~use `apify init` as closest alternative to `actor bootstrap`~
- ~remove the paragraph about "best effort", since this new command appears to be tailor-made for its purpose (imho)~
- ~add reference to `apify create`, it feels like natural extension of `apify init`~
- add a note that `actor bootstrap` is not yet implemented